### PR TITLE
Update to version 3.16 of yEd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 MAINTAINER Mattias Giese <giese@b1-systems.de>
 ENV YED_VERSION 3.14.3
 RUN apt-get update ;\

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ MAINTAINER Mattias Giese <giese@b1-systems.de>
 ENV YED_VERSION 3.14.3
 RUN apt-get update ;\
     apt-get -y dist-upgrade ;\
-    apt-get -y install unzip curl default-jre
+    apt-get -y install unzip wget default-jre
 
-RUN curl http://www.yworks.com/products/yed/demo/yEd-${YED_VERSION}.zip > /yed.zip ;\
+RUN wget --output-document=yed.zip http://www.yworks.com/products/yed/demo/yEd-${YED_VERSION}.zip && \
     unzip /yed.zip -d /opt/
 
 ADD ./entrypoint.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 MAINTAINER Mattias Giese <giese@b1-systems.de>
-ENV YED_VERSION 3.14.3
+ENV YED_VERSION 3.16
 RUN apt-get update ;\
     apt-get -y dist-upgrade ;\
     apt-get -y install unzip wget default-jre


### PR DESCRIPTION
Update to 3.16 of yEd.

Changing the container to be based of Ubuntu 16.04 to get a JRE 8 which a dependency for yEd 3.16.
